### PR TITLE
Use full __aexit__ signature on Dependency

### DIFF
--- a/src/uncalled_for/__init__.py
+++ b/src/uncalled_for/__init__.py
@@ -64,7 +64,12 @@ class Dependency(abc.ABC, Generic[T]):
     @abc.abstractmethod
     async def __aenter__(self) -> T: ...
 
-    async def __aexit__(self, *args: object) -> None:
+    async def __aexit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc_value: BaseException | None,
+        traceback: TracebackType | None,
+    ) -> None:
         pass
 
 


### PR DESCRIPTION
The `*args: object` shorthand on `Dependency.__aexit__` prevents subclasses from using the standard 3-argument form without pyright flagging an incompatible override. This switches to the explicit `(exc_type, exc_value, traceback)` signature, matching `SharedContext.__aexit__` and the `contextlib` async context manager protocol.

🤖 Generated with [Claude Code](https://claude.com/claude-code)