### PR TITLE
Accept bare Dependency subclasses as Annotated metadata

### DIFF
--- a/src/uncalled_for/annotations.py
+++ b/src/uncalled_for/annotations.py
@@ -14,7 +14,12 @@ _annotation_cache: dict[Callable[..., Any], dict[str, list[Dependency[Any]]]] = 
 def get_annotation_dependencies(
     function: Callable[..., Any],
 ) -> dict[str, list[Dependency[Any]]]:
-    """Find ``Dependency`` instances in ``Annotated`` type-hint metadata."""
+    """Find ``Dependency`` instances in ``Annotated`` type-hint metadata.
+
+    Bare ``Dependency`` subclasses are also accepted as a shorthand for a
+    parameterless instance: ``Annotated[T, Dep]`` is equivalent to
+    ``Annotated[T, Dep()]``.
+    """
     if function in _annotation_cache:
         return _annotation_cache[function]
 
@@ -30,9 +35,14 @@ def get_annotation_dependencies(
             continue
         if get_origin(hint) is not Annotated:
             continue
-        dependencies = [a for a in get_args(hint)[1:] if isinstance(a, Dependency)]
+        dependencies: list[Dependency[Any]] = []
+        for a in get_args(hint)[1:]:
+            if isinstance(a, Dependency):
+                dependencies.append(a)
+            elif isinstance(a, type) and issubclass(a, Dependency):
+                dependencies.append(a())
         if dependencies:
-            result[name] = dependencies  # pyright: ignore[reportUnknownMemberType]
+            result[name] = dependencies
 
     _annotation_cache[function] = result
     return result

--- a/tests/test_annotations.py
+++ b/tests/test_annotations.py
@@ -74,6 +74,67 @@ def test_extracts_only_dependency_metadata() -> None:
     assert result["x"] == [dependency]
 
 
+def test_finds_bare_dependency_class_in_annotated_metadata() -> None:
+    async def my_func(x: Annotated[int, Tracker]) -> None: ...
+
+    result = get_annotation_dependencies(my_func)
+    assert "x" in result
+    assert len(result["x"]) == 1
+    assert isinstance(result["x"][0], Tracker)
+
+
+def test_ignores_non_dependency_classes_in_metadata() -> None:
+    async def my_func(x: Annotated[int, str, bytes]) -> None: ...
+
+    result = get_annotation_dependencies(my_func)
+    assert result == {}
+
+
+def test_mixes_bare_class_and_instance_metadata_on_same_parameter() -> None:
+    instance_dep = Tracker()
+
+    class BareDep(Dependency[str]):
+        async def __aenter__(self) -> str: ...
+
+    async def my_func(x: Annotated[int, instance_dep, BareDep]) -> None: ...
+
+    result = get_annotation_dependencies(my_func)
+    assert len(result["x"]) == 2
+    assert result["x"][0] is instance_dep
+    assert isinstance(result["x"][1], BareDep)
+
+
+def test_bare_dependency_class_with_required_args_raises() -> None:
+    class NeedsArgs(Dependency[str]):
+        def __init__(self, required: int) -> None: ...
+
+        async def __aenter__(self) -> str: ...
+
+    async def my_func(x: Annotated[int, NeedsArgs]) -> None: ...
+
+    with pytest.raises(TypeError):
+        get_annotation_dependencies(my_func)
+
+
+async def test_bare_dependency_class_is_resolved_with_bind_and_enter() -> None:
+    bound: list[tuple[str, Any]] = []
+
+    class Recorder(Dependency["Recorder"]):
+        def bind_to_parameter(self, name: str, value: Any) -> "Recorder":
+            bound.append((name, value))
+            return self
+
+        async def __aenter__(self) -> "Recorder":
+            return self
+
+    async def my_func(x: Annotated[int, Recorder]) -> None: ...
+
+    async with resolved_dependencies(my_func, {"x": 42}):
+        pass
+
+    assert bound == [("x", 42)]
+
+
 def test_multiple_dependencies_on_same_parameter() -> None:
     class DependencyA(Dependency[str]):
         async def __aenter__(self) -> str: ...


### PR DESCRIPTION
Today `get_annotation_dependencies` filters with `isinstance(a, Dependency)`, so `Annotated[T, MyDep]` (the class) is silently dropped while `Annotated[T, MyDep()]` (an instance) works.  Now also accept bare `Dependency` subclasses, instantiating them with no args — `Annotated[T, Dep]` becomes shorthand for `Annotated[T, Dep()]`.

Mirrors the pattern docket already uses for `Annotation.annotated_parameters`, so callers can write the cleaner form for parameterless dependencies.  A subclass with required `__init__` args raises `TypeError` at introspection time, which seems fine — it's a programmer error and fails loudly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)